### PR TITLE
ハンズオン詳細ページヘのリンクを修正

### DIFF
--- a/frontend/assets/tmpl/top/_sec_handson.jade
+++ b/frontend/assets/tmpl/top/_sec_handson.jade
@@ -34,6 +34,6 @@ section#handson
                     span.handson__list__head Angular
                     p.handson__list__body Angular入門者ハンズオン
             .btn--handson
-                a.handson__detaill__link(href="/handson.html")
+                a.handson__detaill__link(href="/frontconf2017/handson.html")
                     span HANDSON 詳細をみる
             br


### PR DESCRIPTION
現在、サイトトップの `HANDSON 詳細をみる` リンク先が404になっています。
`/frontconf2017` を間に入れたらページ見れたので、リンク先を修正しました。