### PR TITLE
イベントが終了したので参加受付周りのリンクを削除

### DIFF
--- a/frontend/assets/tmpl/top/_sec_after_party.jade
+++ b/frontend/assets/tmpl/top/_sec_after_party.jade
@@ -10,6 +10,3 @@ section#after-party
 				br
 				| 懇親会LTやスポンサー様から頂いたプレゼントをかけたじゃんけん大会なども企画しております!
 			.after-party__image
-			.btn--after-party()
-				a.after-party__detaill__link(href="http://passmarket.yahoo.co.jp/event/show/detail/01m4unypijyt.html" target="_blank")
-					span 懇親会参加チケット発売中

--- a/frontend/assets/tmpl/top/_sec_hero.jade
+++ b/frontend/assets/tmpl/top/_sec_hero.jade
@@ -25,7 +25,3 @@ section#hero
         a(href="#access").hero__infomation__to-access
           i.fa.fa-map-marker
           | アクセス
-    .hero__action-area
-      .btn
-        a(href="http://passmarket.yahoo.co.jp/event/show/detail/01m4unypijyt.html" target="_blank")
-          span 参加受付中！


### PR DESCRIPTION
クロージング用のページに切り替えても良いですが、一旦。